### PR TITLE
Add 3D venue editor workflows

### DIFF
--- a/parrot/fixtures/position_manager.py
+++ b/parrot/fixtures/position_manager.py
@@ -4,9 +4,9 @@ import json
 import os
 import numpy as np
 from beartype import beartype
-from typing import Optional
+from typing import Any, Optional
 from parrot.state import State
-from parrot.patch_bay import venue_patches
+from parrot.patch_bay import get_default_venue_metadata, venue_patches
 from parrot.fixtures.base import FixtureBase, FixtureGroup
 
 
@@ -24,6 +24,8 @@ class FixturePositionManager:
             state: Global state object (provides current venue)
         """
         self.state = state
+        self.venue_metadata: dict[str, Any] = {}
+        self._loaded_layout_data: dict[str, Any] = {}
 
         # Subscribe to venue changes to reload positions
         self.state.events.on_venue_change += self._on_venue_change
@@ -33,6 +35,9 @@ class FixturePositionManager:
 
     def _on_venue_change(self, venue):
         """Reload positions when venue changes"""
+        self._load_and_apply_positions()
+
+    def reload_current_venue_layout(self) -> None:
         self._load_and_apply_positions()
 
     def _get_all_fixtures(self) -> list[FixtureBase]:
@@ -59,10 +64,12 @@ class FixturePositionManager:
 
     def _load_and_apply_positions(self):
         """Load fixture positions from JSON file and apply them to fixture objects"""
-        filename = f"{self.state.venue.name}_gui.json"
+        filename = self.get_layout_filename()
 
         # Get all fixtures from patch bay (golden source)
         fixtures = self._get_all_fixtures()
+        self.venue_metadata = get_default_venue_metadata(self.state.venue)
+        self._loaded_layout_data = {}
 
         if not os.path.exists(filename):
             # Use default positions if no saved file
@@ -72,6 +79,22 @@ class FixturePositionManager:
         try:
             with open(filename, "r") as f:
                 data = json.load(f)
+            self._loaded_layout_data = data
+
+            venue_metadata = data.get("__venue__")
+            if isinstance(venue_metadata, dict):
+                self.venue_metadata["floor_size_feet"] = float(
+                    venue_metadata.get(
+                        "floor_size_feet", self.venue_metadata["floor_size_feet"]
+                    )
+                )
+                video_wall = venue_metadata.get("video_wall")
+                if isinstance(video_wall, dict):
+                    merged_video_wall = dict(self.venue_metadata["video_wall"])
+                    for key in ("x", "y", "z", "width", "height"):
+                        if key in video_wall:
+                            merged_video_wall[key] = float(video_wall[key])
+                    self.venue_metadata["video_wall"] = merged_video_wall
 
             # Apply positions to fixtures
             for fixture in fixtures:
@@ -140,6 +163,9 @@ class FixturePositionManager:
         fixture.z = 3.0
         fixture.orientation = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
 
+    def get_layout_filename(self) -> str:
+        return f"{self.state.venue.name}_gui.json"
+
     def get_fixture_position(
         self, fixture: FixtureBase
     ) -> Optional[tuple[float, float, float]]:
@@ -147,8 +173,11 @@ class FixturePositionManager:
         Get the position of a fixture as a tuple (x, y, z).
         Returns None if position is not set.
         """
-        if hasattr(fixture, "x") and hasattr(fixture, "y") and hasattr(fixture, "z"):
-            return (fixture.x, fixture.y, fixture.z)
+        x = getattr(fixture, "x", None)
+        y = getattr(fixture, "y", None)
+        z = getattr(fixture, "z", None)
+        if x is not None and y is not None and z is not None:
+            return (float(x), float(y), float(z))
         return None
 
     def get_fixture_orientation(self, fixture: FixtureBase) -> Optional[np.ndarray]:
@@ -156,6 +185,60 @@ class FixturePositionManager:
         Get the orientation of a fixture as a quaternion (numpy array).
         Returns None if orientation is not set.
         """
-        if hasattr(fixture, "orientation"):
-            return fixture.orientation
+        orientation = getattr(fixture, "orientation", None)
+        if orientation is not None:
+            return orientation
         return None
+
+    def set_fixture_position(
+        self, fixture: FixtureBase, x: float, y: float, z: float
+    ) -> None:
+        fixture.x = float(x)
+        fixture.y = float(y)
+        fixture.z = float(z)
+
+    def set_fixture_orientation(
+        self, fixture: FixtureBase, orientation: np.ndarray
+    ) -> None:
+        fixture.orientation = np.array(orientation, dtype=np.float32)
+
+    def save_current_venue_layout(self) -> None:
+        fixtures = self._get_all_fixtures()
+        data: dict[str, Any] = {
+            "__venue__": {
+                "floor_size_feet": float(self.venue_metadata["floor_size_feet"]),
+                "video_wall": dict(self.venue_metadata["video_wall"]),
+            }
+        }
+        for fixture in fixtures:
+            position = self.get_fixture_position(fixture)
+            orientation = self.get_fixture_orientation(fixture)
+            if position is None or orientation is None:
+                continue
+            data[fixture.id] = {
+                "x": float(position[0]),
+                "y": float(position[1]),
+                "z": float(position[2]),
+                "orientation": [float(value) for value in orientation.tolist()],
+            }
+
+        with open(self.get_layout_filename(), "w") as handle:
+            json.dump(data, handle, indent=2)
+
+    def get_floor_size_feet(self) -> float:
+        return float(self.venue_metadata["floor_size_feet"])
+
+    def set_floor_size_feet(self, floor_size_feet: float) -> None:
+        self.venue_metadata["floor_size_feet"] = float(floor_size_feet)
+        self.save_current_venue_layout()
+
+    def get_video_wall_config(self) -> dict[str, float]:
+        return dict(self.venue_metadata["video_wall"])
+
+    def set_video_wall_config(self, video_wall: dict[str, float]) -> None:
+        merged_video_wall = dict(self.venue_metadata["video_wall"])
+        for key in ("x", "y", "z", "width", "height"):
+            if key in video_wall:
+                merged_video_wall[key] = float(video_wall[key])
+        self.venue_metadata["video_wall"] = merged_video_wall
+        self.save_current_venue_layout()

--- a/parrot/gl_window_app.py
+++ b/parrot/gl_window_app.py
@@ -3,6 +3,7 @@
 import time
 import moderngl_window as mglw
 import moderngl as mgl
+import imgui
 from beartype import beartype
 import numpy as np
 
@@ -179,7 +180,10 @@ def run_gl_window_app(args):
         break
 
     # Initialize overlay UI
-    overlay = OverlayUI(pyglet_window, state)
+    overlay = OverlayUI(pyglet_window, state, fixture_renderer.editor)
+    fixture_renderer.editor.set_patch_change_callback(
+        lambda: (director.setup_patch(), fixture_renderer.reload_fixtures())
+    )
 
     # Check for start-with-overlay flag
     if getattr(args, "start_with_overlay", False):
@@ -422,21 +426,29 @@ def run_gl_window_app(args):
 
         def on_mouse_press(self, x, y, button, modifiers):
             # Only handle left mouse button
+            if overlay.visible and imgui.get_io().want_capture_mouse:
+                return
             if button == pyglet.window.mouse.LEFT:
                 input_events.handle_mouse_press(float(x), float(y))
 
         def on_mouse_release(self, x, y, button, modifiers):
             # Only handle left mouse button
+            if overlay.visible and imgui.get_io().want_capture_mouse:
+                return
             if button == pyglet.window.mouse.LEFT:
                 input_events.handle_mouse_release(float(x), float(y))
 
         def on_mouse_drag(self, x, y, dx, dy, buttons, modifiers):
             # Only handle left mouse button drag
+            if overlay.visible and imgui.get_io().want_capture_mouse:
+                return
             if buttons & pyglet.window.mouse.LEFT:
                 input_events.handle_mouse_drag(float(x), float(y))
 
         def on_mouse_scroll(self, x, y, scroll_x, scroll_y):
             # Forward scroll events for camera zoom
+            if overlay.visible and imgui.get_io().want_capture_mouse:
+                return
             input_events.handle_mouse_scroll(float(scroll_x), float(scroll_y))
 
     mouse_handler = MouseHandler()

--- a/parrot/patch_bay.py
+++ b/parrot/patch_bay.py
@@ -1,14 +1,19 @@
+import enum
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from beartype import beartype
+
+from parrot.fixtures.base import FixtureBase, FixtureGroup, ManualGroup
+from parrot.fixtures.chauvet.intimidator110 import ChauvetSpot110_12Ch
+from parrot.fixtures.chauvet.intimidator160 import ChauvetSpot160_12Ch
+from parrot.fixtures.chauvet.rogue_beam_r2 import ChauvetRogueBeamR2
+from parrot.fixtures.chauvet.slimpar_pro_q import ChauvetSlimParProQ_5Ch
 from parrot.fixtures.led_par import ParRGB, ParRGBAWU
 from parrot.fixtures.motionstrip import Motionstrip38
-from parrot.fixtures.base import FixtureBase, FixtureGroup, ManualGroup
-
-from parrot.fixtures.chauvet.intimidator110 import ChauvetSpot110_12Ch
-from parrot.fixtures.chauvet.rogue_beam_r2 import ChauvetRogueBeamR2
-from parrot.fixtures.chauvet.intimidator160 import ChauvetSpot160_12Ch
-from parrot.fixtures.chauvet.gigbar import ChauvetGigBarMoveILS
-from parrot.fixtures.chauvet.slimpar_pro_q import ChauvetSlimParProQ_5Ch
-import enum
-
 from parrot.fixtures.oultia.laser import TwoBeamLaser
 from parrot.fixtures.uking.laser import FiveBeamLaser
 from parrot.utils.dmx_utils import Universe
@@ -17,143 +22,411 @@ venues = enum.Enum(
     "Venues", ["dmack", "mtn_lotus", "truckee_theatre", "crux_test", "big"]
 )
 
-# Create manual control fixtures for each venue
-truckee_manual_fixtures = [
-    *[FixtureBase(i, f"Manual Bulb {i}", 1) for i in range(1, 9)],
-]
 
-# Create manual control groups for each venue
-manual_groups = {
-    venues.truckee_theatre: ManualGroup(
-        truckee_manual_fixtures, "Truckee Manual Control"
-    ),
-    venues.dmack: None,
-    venues.mtn_lotus: ManualGroup(
-        [
-            FixtureBase(1, "SR spot", 1, universe=Universe.art1),
-            FixtureBase(2, "SL spot", 1, universe=Universe.art1),
+@beartype
+@dataclass(frozen=True)
+class CustomVenue:
+    name: str
+    display_name: str
+
+
+DEFAULT_FLOOR_SIZE_FEET = 10.0
+DEFAULT_VIDEO_WALL = {
+    "x": 0.0,
+    "y": 3.0,
+    "z": -4.5,
+    "width": 10.0,
+    "height": 6.0,
+}
+EDITOR_CONFIG_PATH = Path("venue_editor.json")
+
+SUPPORTED_EDITOR_FIXTURE_TYPES = {
+    "ParRGB": "LED Par RGB",
+    "ParRGBAWU": "LED Par RGBAWU",
+    "Motionstrip38": "Motionstrip 38",
+    "ChauvetSpot110_12Ch": "Chauvet Intimidator 110",
+    "ChauvetSpot160_12Ch": "Chauvet Intimidator 160",
+    "ChauvetSlimParProQ_5Ch": "Chauvet SlimPAR Pro Q",
+    "ChauvetRogueBeamR2": "Chauvet Rogue Beam R2",
+    "TwoBeamLaser": "Oultia 2 Beam Laser",
+    "FiveBeamLaser": "Uking 5 Beam Laser",
+}
+
+manual_groups: dict[Any, ManualGroup | None] = {}
+venue_patches: dict[Any, list[FixtureBase | FixtureGroup]] = {}
+custom_venues_by_name: dict[str, CustomVenue] = {}
+venue_defaults: dict[Any, dict[str, Any]] = {}
+
+
+def _fixture(
+    fixture_type: str,
+    address: int,
+    universe: str = Universe.default.value,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    spec = {
+        "kind": "fixture",
+        "type": fixture_type,
+        "address": int(address),
+        "universe": universe,
+    }
+    spec.update(kwargs)
+    return spec
+
+
+def _group(name: str, fixtures: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"kind": "group", "name": name, "fixtures": fixtures}
+
+
+def _default_patch_specs() -> dict[Any, list[dict[str, Any]]]:
+    return {
+        venues.dmack: [
+            _fixture("ChauvetSpot160_12Ch", 1),
+            _fixture("ChauvetSpot110_12Ch", 140),
+            *[_fixture("ParRGB", i) for i in range(12, 48, 7)],
+            _fixture("Motionstrip38", 154, pan_lower=0, pan_upper=256, invert_pan=True),
+            _fixture("Motionstrip38", 59, pan_lower=0, pan_upper=256, invert_pan=True),
+            _fixture("FiveBeamLaser", 100),
+            _fixture("TwoBeamLaser", 120),
+        ],
+        venues.mtn_lotus: [
+            *[
+                _fixture("ParRGBAWU", i, universe=Universe.art1.value)
+                for i in range(10, 90, 10)
+            ],
+            _fixture("Motionstrip38", 90, pan_lower=0, pan_upper=256),
+            _fixture("ParRGB", 195),
+            _fixture("ParRGB", 205),
+            _fixture("ChauvetSpot160_12Ch", 182),
+            _fixture("TwoBeamLaser", 220),
+            _fixture("Motionstrip38", 130, pan_lower=0, pan_upper=256),
+            _fixture("ParRGB", 230),
+            _fixture("ParRGB", 238),
+            _fixture("ChauvetSpot110_12Ch", 170),
+        ],
+        venues.truckee_theatre: [
+            _group(
+                "Sidelights",
+                [
+                    *[
+                        _fixture("ChauvetSlimParProQ_5Ch", i)
+                        for i in range(154, 170, 5)
+                    ],
+                    *[
+                        _fixture("ChauvetSlimParProQ_5Ch", i)
+                        for i in range(174, 190, 5)
+                    ],
+                ],
+            ),
+            _group(
+                "Front led wash",
+                [
+                    _fixture("ChauvetSlimParProQ_5Ch", i)
+                    for i in range(30, 66, 5)
+                ],
+            ),
+            _group(
+                "Moving heads crescent",
+                [
+                    *[
+                        _fixture("ChauvetRogueBeamR2", i)
+                        for i in range(191, 191 + 15 * 6, 15)
+                    ],
+                    *[_fixture("ParRGB", i) for i in range(67, 67 + 6 * 7, 7)],
+                ],
+            ),
+            _group(
+                "Mirror ball",
+                [
+                    _fixture("ChauvetSpot160_12Ch", 1),
+                    _fixture("ChauvetSpot110_12Ch", 13),
+                    _fixture("ParRGB", 450),
+                    _fixture("ParRGB", 460),
+                ],
+            ),
+            _group(
+                "Motion strip (doubled)",
+                [
+                    _fixture("Motionstrip38", 300, pan_lower=128, pan_upper=256),
+                    _fixture("Motionstrip38", 338, pan_lower=128, pan_upper=256),
+                ],
+            ),
+            _group(
+                "Spare Pars",
+                [_fixture("ParRGB", i) for i in range(400, 400 + 4 * 7, 7)],
+            ),
+        ],
+        venues.crux_test: [
+            _group(
+                "Rogue Beams",
+                [_fixture("ChauvetRogueBeamR2", 1), _fixture("ChauvetRogueBeamR2", 16)],
+            ),
+        ],
+        venues.big: [
+            *[_fixture("ChauvetSpot160_12Ch", i) for i in range(10, 90, 10)],
+            *[_fixture("ChauvetSpot160_12Ch", i) for i in range(100, 180, 10)],
+            *[_fixture("ChauvetSpot160_12Ch", i) for i in range(200, 400, 12)],
+        ],
+    }
+
+
+def _default_manual_group_specs() -> dict[Any, list[dict[str, Any]]]:
+    return {
+        venues.truckee_theatre: [
+            _fixture("FixtureBase", i, name=f"Manual Bulb {i}", width=1)
+            for i in range(1, 9)
+        ],
+        venues.mtn_lotus: [
+            _fixture(
+                "FixtureBase",
+                1,
+                universe=Universe.art1.value,
+                name="SR spot",
+                width=1,
+            ),
+            _fixture(
+                "FixtureBase",
+                2,
+                universe=Universe.art1.value,
+                name="SL spot",
+                width=1,
+            ),
+        ],
+    }
+
+
+def _read_editor_config() -> dict[str, Any]:
+    if not EDITOR_CONFIG_PATH.exists():
+        return {"custom_venues": {}, "fixture_additions": {}}
+    with EDITOR_CONFIG_PATH.open("r") as handle:
+        data = json.load(handle)
+    return {
+        "custom_venues": data.get("custom_venues", {}),
+        "fixture_additions": data.get("fixture_additions", {}),
+    }
+
+
+def _write_editor_config(data: dict[str, Any]) -> None:
+    with EDITOR_CONFIG_PATH.open("w") as handle:
+        json.dump(data, handle, indent=2)
+
+
+def _universe_from_spec(spec: dict[str, Any]) -> Universe:
+    return Universe(spec.get("universe", Universe.default.value))
+
+
+def _instantiate_fixture(spec: dict[str, Any]) -> FixtureBase:
+    fixture_type = spec["type"]
+    address = int(spec["address"])
+    universe = _universe_from_spec(spec)
+
+    if fixture_type == "ParRGB":
+        return ParRGB(address, universe=universe)
+    if fixture_type == "ParRGBAWU":
+        return ParRGBAWU(address, universe=universe)
+    if fixture_type == "Motionstrip38":
+        return Motionstrip38(
+            address,
+            pan_lower=int(spec.get("pan_lower", 0)),
+            pan_upper=int(spec.get("pan_upper", 255)),
+            invert_pan=bool(spec.get("invert_pan", False)),
+            universe=universe,
+        )
+    if fixture_type == "ChauvetSpot110_12Ch":
+        return ChauvetSpot110_12Ch(address, universe=universe)
+    if fixture_type == "ChauvetSpot160_12Ch":
+        return ChauvetSpot160_12Ch(address, universe=universe)
+    if fixture_type == "ChauvetSlimParProQ_5Ch":
+        return ChauvetSlimParProQ_5Ch(address, universe=universe)
+    if fixture_type == "ChauvetRogueBeamR2":
+        return ChauvetRogueBeamR2(address, universe=universe)
+    if fixture_type == "TwoBeamLaser":
+        return TwoBeamLaser(address)
+    if fixture_type == "FiveBeamLaser":
+        return FiveBeamLaser(address)
+    if fixture_type == "FixtureBase":
+        return FixtureBase(
+            address,
+            spec.get("name", f"Fixture {address}"),
+            int(spec.get("width", 1)),
+            universe=universe,
+        )
+    raise ValueError(f"Unsupported fixture type '{fixture_type}'")
+
+
+def _instantiate_item(spec: dict[str, Any]) -> FixtureBase | FixtureGroup:
+    if spec.get("kind") == "group":
+        return FixtureGroup(
+            [_instantiate_fixture(fixture_spec) for fixture_spec in spec["fixtures"]],
+            spec["name"],
+        )
+    return _instantiate_fixture(spec)
+
+
+def _ensure_custom_venue(venue_name: str, display_name: str) -> CustomVenue:
+    existing = custom_venues_by_name.get(venue_name)
+    if existing is not None:
+        return existing
+    venue = CustomVenue(name=venue_name, display_name=display_name)
+    custom_venues_by_name[venue_name] = venue
+    return venue
+
+
+def _refresh_patch_state() -> None:
+    editor_config = _read_editor_config()
+    patch_specs = _default_patch_specs()
+    manual_specs = _default_manual_group_specs()
+    configured_custom_names = set(editor_config["custom_venues"].keys())
+
+    venue_patches.clear()
+    manual_groups.clear()
+    venue_defaults.clear()
+    for custom_name in list(custom_venues_by_name.keys()):
+        if custom_name not in configured_custom_names:
+            del custom_venues_by_name[custom_name]
+
+    for builtin_venue in venues:
+        additions = editor_config["fixture_additions"].get(builtin_venue.name, [])
+        combined_specs = [*patch_specs.get(builtin_venue, []), *additions]
+        venue_patches[builtin_venue] = [_instantiate_item(spec) for spec in combined_specs]
+        manual_spec = manual_specs.get(builtin_venue)
+        manual_groups[builtin_venue] = (
+            ManualGroup(
+                [_instantiate_fixture(spec) for spec in manual_spec],
+                f"{get_venue_display_name(builtin_venue)} Manual Control",
+            )
+            if manual_spec
+            else None
+        )
+        venue_defaults[builtin_venue] = {
+            "floor_size_feet": DEFAULT_FLOOR_SIZE_FEET,
+            "video_wall": dict(DEFAULT_VIDEO_WALL),
+        }
+
+    for venue_name, venue_data in editor_config["custom_venues"].items():
+        display_name = venue_data.get("display_name", venue_name)
+        custom_venue = _ensure_custom_venue(venue_name, display_name)
+        venue_patches[custom_venue] = [
+            _instantiate_item(spec) for spec in venue_data.get("fixtures", [])
         ]
-    ),
-    venues.crux_test: None,
-    venues.big: None,
-}
-
-venue_patches = {
-    venues.dmack: [
-        ChauvetSpot160_12Ch(
-            patch=1,
-        ),
-        ChauvetSpot110_12Ch(
-            patch=140,
-        ),
-        *[ParRGB(i) for i in range(12, 48, 7)],
-        Motionstrip38(154, 0, 256, invert_pan=True),
-        Motionstrip38(59, 0, 256, invert_pan=True),
-        FiveBeamLaser(100),
-        TwoBeamLaser(120),
-        # ChauvetRotosphere_28Ch(164),
-    ],
-    venues.mtn_lotus: [
-        # Address 1 and 2 are the front spots.
-        *[
-            ParRGBAWU(i, universe=Universe.art1) for i in range(10, 90, 10)
-        ],  # 10-20-30-40 is back line of pars. 50-60-70-80 is front line of pars.
-        # Stage left column
-        Motionstrip38(90, 0, 256),  # Stage left column
-        ParRGB(195),  # Stage left top par
-        ParRGB(205),  # Stage left bottom par
-        ChauvetSpot160_12Ch(182),  # Stage left spot
-        # --------
-        TwoBeamLaser(220),
-        # --------
-        # Stage right column
-        Motionstrip38(130, 0, 256),  # Stage right column
-        ParRGB(230),  # Stage right top par
-        ParRGB(238),  # Stage right bottom par
-        ChauvetSpot110_12Ch(170),  # Stage right spot
-        # --------
-    ],
-    venues.truckee_theatre: [
-        # 6 COLORband PiX fixtures (36 channels each)
-        # FixtureGroup(
-        #     [ChauvetColorBandPiX_36Ch(i) for i in range(194, 375, 36)],
-        #     "ColorBand wash",
-        # ),
-        # 6 SlimPAR Pro H fixtures (7 channels each)
-        # FixtureGroup(
-        #     # [ChauvetSlimParProH_7Ch(i) for i in range(70, 106, 7)],
-        #     [ChauvetSlimParProH_7Ch(i) for i in range(112, 148, 7)],
-        #     "Stage overhead",
-        # ),
-        # 6 more SlimPAR Pro H fixtures (7 channels each)
-        # 4 SlimPAR Pro Q fixtures (5 channels each)
-        FixtureGroup(
-            [ChauvetSlimParProQ_5Ch(i) for i in range(154, 170, 5)]
-            + [ChauvetSlimParProQ_5Ch(i) for i in range(174, 190, 5)],
-            "Sidelights",
-        ),
-        # 8 more SlimPAR Pro Q fixtures (5 channels each)
-        FixtureGroup(
-            [ChauvetSlimParProQ_5Ch(i) for i in range(30, 66, 5)],
-            "Front led wash",
-        ),
-        FixtureGroup(
-            [
-                *[ChauvetRogueBeamR2(i) for i in range(191, 191 + 15 * 6, 15)],
-                *[ParRGB(i) for i in range(67, 67 + 6 * 7, 7)],
-            ],
-            "Moving heads crescent",
-        ),
-        FixtureGroup(
-            [
-                ChauvetSpot160_12Ch(
-                    1,
-                ),
-                ChauvetSpot110_12Ch(
-                    13,
-                ),
-                ParRGB(450),
-                ParRGB(460),
-            ],
-            "Mirror ball",
-        ),
-        FixtureGroup(
-            [
-                Motionstrip38(300, pan_lower=128, pan_upper=256),
-                Motionstrip38(300 + 38, pan_lower=128, pan_upper=256),
-            ],
-            "Motion strip (doubled)",
-        ),
-        FixtureGroup([ParRGB(i) for i in range(400, 400 + 4 * 7, 7)], "Spare Pars"),
-    ],
-    venues.crux_test: [
-        FixtureGroup(
-            [ChauvetRogueBeamR2(1), ChauvetRogueBeamR2(16)],
-            "Rogue Beams",
-        ),
-    ],
-    venues.big: [
-        # 8 moving lights along top of video wall (back wall, high)
-        *[
-            ChauvetSpot160_12Ch(i) for i in range(10, 90, 10)
-        ],  # 10, 20, 30, 40, 50, 60, 70, 80
-        # 8 moving lights along base of video wall (audience side, low)
-        *[
-            ChauvetSpot160_12Ch(i) for i in range(100, 180, 10)
-        ],  # 100, 110, 120, 130, 140, 150, 160, 170
-        # 4x4 grid of moving lights in ceiling (upside down, pointing down)
-        *[
-            ChauvetSpot160_12Ch(i) for i in range(200, 400, 12)
-        ],  # 200, 212, 224, 236, 248, 260, 272, 284, 296, 308, 320, 332, 344, 356, 368, 380
-    ],
-}
+        manual_groups[custom_venue] = None
+        venue_defaults[custom_venue] = {
+            "floor_size_feet": float(
+                venue_data.get("default_floor_size_feet", DEFAULT_FLOOR_SIZE_FEET)
+            ),
+            "video_wall": dict(DEFAULT_VIDEO_WALL),
+        }
 
 
-def get_manual_group(venue):
-    """Get the manual control group for a venue."""
+def _slugify_venue_name(display_name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "_", display_name.strip().lower()).strip("_")
+    return slug or "venue"
+
+
+@beartype
+def get_supported_fixture_types() -> list[tuple[str, str]]:
+    return list(SUPPORTED_EDITOR_FIXTURE_TYPES.items())
+
+
+@beartype
+def get_all_venues() -> list[Any]:
+    return [*list(venues), *custom_venues_by_name.values()]
+
+
+@beartype
+def get_venue_display_name(venue: Any) -> str:
+    display_name = getattr(venue, "display_name", None)
+    if isinstance(display_name, str) and display_name:
+        return display_name
+    return venue.name.replace("_", " ").title()
+
+
+@beartype
+def resolve_venue(name: str) -> Any | None:
+    for builtin_venue in venues:
+        if builtin_venue.name == name:
+            return builtin_venue
+    return custom_venues_by_name.get(name)
+
+
+@beartype
+def get_default_venue_metadata(venue: Any) -> dict[str, Any]:
+    defaults = venue_defaults.get(
+        venue,
+        {"floor_size_feet": DEFAULT_FLOOR_SIZE_FEET, "video_wall": dict(DEFAULT_VIDEO_WALL)},
+    )
+    return {
+        "floor_size_feet": float(defaults["floor_size_feet"]),
+        "video_wall": dict(defaults["video_wall"]),
+    }
+
+
+@beartype
+def add_custom_venue(display_name: str) -> CustomVenue:
+    cleaned_name = display_name.strip()
+    if not cleaned_name:
+        raise ValueError("Venue name cannot be empty")
+
+    editor_config = _read_editor_config()
+    venue_name = _slugify_venue_name(cleaned_name)
+    if resolve_venue(venue_name) is not None:
+        raise ValueError(f"Venue '{cleaned_name}' already exists")
+
+    editor_config["custom_venues"][venue_name] = {
+        "display_name": cleaned_name,
+        "fixtures": [],
+        "default_floor_size_feet": DEFAULT_FLOOR_SIZE_FEET,
+    }
+    _write_editor_config(editor_config)
+    _refresh_patch_state()
+    return custom_venues_by_name[venue_name]
+
+
+@beartype
+def add_fixture_to_venue(venue: Any, fixture_type: str, address: int) -> FixtureBase:
+    if fixture_type not in SUPPORTED_EDITOR_FIXTURE_TYPES:
+        raise ValueError(f"Unsupported fixture type '{fixture_type}'")
+    if address < 1 or address > 512:
+        raise ValueError("Fixture address must be between 1 and 512")
+
+    editor_config = _read_editor_config()
+    fixture_spec = _fixture(fixture_type, address)
+
+    if isinstance(venue, CustomVenue):
+        venue_entry = editor_config["custom_venues"].get(venue.name)
+        if venue_entry is None:
+            raise ValueError(f"Unknown custom venue '{venue.name}'")
+        venue_entry.setdefault("fixtures", []).append(fixture_spec)
+    else:
+        editor_config["fixture_additions"].setdefault(venue.name, []).append(fixture_spec)
+
+    _write_editor_config(editor_config)
+    _refresh_patch_state()
+
+    for item in venue_patches[venue]:
+        if isinstance(item, FixtureGroup):
+            for fixture in item.fixtures:
+                if type(fixture).__name__ == fixture_type and fixture.address == address:
+                    return fixture
+        elif type(item).__name__ == fixture_type and item.address == address:
+            return item
+
+    raise RuntimeError("New fixture could not be found after adding it")
+
+
+@beartype
+def get_manual_group(venue: Any) -> ManualGroup | None:
     return manual_groups.get(venue)
 
 
-def has_manual_dimmer(venue):
-    """Check if a venue has manual dimmers."""
+@beartype
+def has_manual_dimmer(venue: Any) -> bool:
     return manual_groups.get(venue) is not None
+
+
+@beartype
+def reload_patch_bay_configuration() -> None:
+    _refresh_patch_state()
+
+
+_refresh_patch_state()

--- a/parrot/state.py
+++ b/parrot/state.py
@@ -6,7 +6,7 @@ from beartype import beartype
 from parrot.director.mode import Mode
 from parrot.vj.vj_mode import VJMode
 from parrot.director.themes import themes, get_theme_by_name
-from parrot.patch_bay import venues
+from parrot.patch_bay import venues, resolve_venue
 
 
 @beartype
@@ -220,14 +220,9 @@ class State:
                 self._theme = themes[state_data["theme_index"]]
 
             if "venue_name" in state_data and state_data["venue_name"]:
-                # Find venue by name
-                for venue in venues.__dict__.values():
-                    if (
-                        hasattr(venue, "name")
-                        and venue.name == state_data["venue_name"]
-                    ):
-                        self._venue = venue
-                        break
+                loaded_venue = resolve_venue(state_data["venue_name"])
+                if loaded_venue is not None:
+                    self._venue = loaded_venue
 
             if "manual_dimmer" in state_data:
                 self._manual_dimmer = state_data["manual_dimmer"]

--- a/parrot/test_venue_editor.py
+++ b/parrot/test_venue_editor.py
@@ -1,0 +1,148 @@
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from parrot.fixtures.position_manager import FixturePositionManager
+from parrot.patch_bay import (
+    add_custom_venue,
+    add_fixture_to_venue,
+    get_all_venues,
+    reload_patch_bay_configuration,
+    resolve_venue,
+    venue_patches,
+    venues,
+)
+from parrot.state import State
+from parrot.venue_editor import SelectionTarget, VenueEditorController
+from parrot.vj.renderers.room_3d import Room3DRenderer
+
+
+@pytest.fixture
+def temp_workspace():
+    original_cwd = os.getcwd()
+    temp_dir = tempfile.mkdtemp()
+    os.chdir(temp_dir)
+    reload_patch_bay_configuration()
+    yield temp_dir
+    os.chdir(original_cwd)
+    reload_patch_bay_configuration()
+
+    import shutil
+
+    shutil.rmtree(temp_dir)
+
+
+def test_can_add_custom_venue_and_fixture(temp_workspace):
+    custom_venue = add_custom_venue("Warehouse Alpha")
+
+    assert resolve_venue("warehouse_alpha") == custom_venue
+    assert custom_venue in get_all_venues()
+    assert venue_patches[custom_venue] == []
+
+    new_fixture = add_fixture_to_venue(custom_venue, "ParRGB", 55)
+
+    assert new_fixture.address == 55
+    assert len(venue_patches[custom_venue]) == 1
+
+
+def test_position_manager_persists_floor_size_and_video_wall(temp_workspace):
+    state = State()
+    state.set_venue(venues.dmack)
+    position_manager = FixturePositionManager(state)
+
+    position_manager.set_floor_size_feet(24.0)
+    position_manager.set_video_wall_config(
+        {"x": 1.5, "y": 4.0, "z": -3.25, "width": 8.0, "height": 5.0}
+    )
+
+    reloaded_manager = FixturePositionManager(state)
+    reloaded_video_wall = reloaded_manager.get_video_wall_config()
+
+    assert reloaded_manager.get_floor_size_feet() == pytest.approx(24.0)
+    assert reloaded_video_wall["x"] == pytest.approx(1.5)
+    assert reloaded_video_wall["y"] == pytest.approx(4.0)
+    assert reloaded_video_wall["z"] == pytest.approx(-3.25)
+    assert reloaded_video_wall["width"] == pytest.approx(8.0)
+    assert reloaded_video_wall["height"] == pytest.approx(5.0)
+
+
+class FakeRoomRenderer:
+    def project_world_to_screen(self, position):
+        return (position[0] * 100.0, position[1] * 100.0)
+
+    def convert_3d_to_2d(self, room_x, room_y, room_z):
+        return (room_x, room_z, room_y)
+
+    def set_floor_size_feet(self, floor_size_feet):
+        self.floor_size_feet = floor_size_feet
+
+    def render_axis_gizmo(self, *args, **kwargs):
+        return None
+
+
+class FakeFixtureRenderer:
+    def __init__(self, fixture):
+        self.fixture = fixture
+        self.position = (10.0, 20.0, 3.0)
+        self.orientation = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+
+    def set_position(self, x, y, z):
+        self.position = (x, y, z)
+
+    def get_3d_position(self, canvas_size):
+        return (self.position[0], self.position[2], self.position[1])
+
+
+def test_editor_moves_and_rotates_selected_fixture(temp_workspace):
+    state = State()
+    state.set_show_fixture_mode(True)
+    state.set_venue(venues.dmack)
+    position_manager = FixturePositionManager(state)
+
+    fixture = venue_patches[venues.dmack][0]
+    renderer = FakeFixtureRenderer(fixture)
+    position_manager.set_fixture_position(fixture, *renderer.position)
+    position_manager.set_fixture_orientation(
+        fixture, np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+    )
+
+    editor = VenueEditorController(state, position_manager)
+    editor.update_scene(
+        FakeRoomRenderer(),
+        [renderer],
+        (500.0, 500.0),
+        position_manager.get_video_wall_config(),
+    )
+    editor.selected_target = SelectionTarget(kind="fixture", fixture_id=fixture.id)
+
+    editor._move_selected("x", 2.0)
+
+    assert renderer.position[0] == pytest.approx(12.0)
+    assert position_manager.get_fixture_position(fixture)[0] == pytest.approx(12.0)
+
+    editor._rotate_selected("y", 1)
+
+    assert not np.allclose(
+        position_manager.get_fixture_orientation(fixture),
+        np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+    )
+
+
+def test_floor_size_coordinate_conversion_round_trips():
+    room_renderer = Room3DRenderer.__new__(Room3DRenderer)
+    room_renderer.floor_size_feet = 24.0
+
+    room_x, room_y, room_z = Room3DRenderer.convert_2d_to_3d(
+        room_renderer, 500.0, 500.0, 3.0, 500.0, 500.0
+    )
+    canvas_x, canvas_y, height = Room3DRenderer.convert_3d_to_2d(
+        room_renderer, room_x, room_y, room_z
+    )
+
+    assert room_x == pytest.approx(12.0)
+    assert room_z == pytest.approx(12.0)
+    assert canvas_x == pytest.approx(500.0)
+    assert canvas_y == pytest.approx(500.0)
+    assert height == pytest.approx(3.0)

--- a/parrot/utils/input_events.py
+++ b/parrot/utils/input_events.py
@@ -5,7 +5,7 @@ Allows 3D renderers and other components to receive input events.
 """
 
 from beartype import beartype
-from beartype.typing import Optional, Callable
+from beartype.typing import Callable, Optional
 
 
 @beartype
@@ -33,11 +33,11 @@ class InputEvents:
         self.mouse_drag_start_x = 0.0
         self.mouse_drag_start_y = 0.0
 
-        # Registered callbacks
-        self.on_mouse_drag: Optional[Callable[[float, float], None]] = None
-        self.on_mouse_press: Optional[Callable[[float, float], None]] = None
-        self.on_mouse_release: Optional[Callable[[float, float], None]] = None
-        self.on_mouse_scroll: Optional[Callable[[float, float], None]] = None
+        # Registered callbacks. Returning True consumes the event.
+        self.on_mouse_drag: list[Callable[[float, float], bool | None]] = []
+        self.on_mouse_press: list[Callable[[float, float], bool | None]] = []
+        self.on_mouse_release: list[Callable[[float, float], bool | None]] = []
+        self.on_mouse_scroll: list[Callable[[float, float], bool | None]] = []
 
     def handle_mouse_press(self, x: float, y: float):
         """Called when mouse button is pressed"""
@@ -47,8 +47,9 @@ class InputEvents:
         self.mouse_x = x
         self.mouse_y = y
 
-        if self.on_mouse_press:
-            self.on_mouse_press(x, y)
+        for callback in list(self.on_mouse_press):
+            if callback(x, y):
+                break
 
     def handle_mouse_release(self, x: float, y: float):
         """Called when mouse button is released"""
@@ -56,8 +57,9 @@ class InputEvents:
         self.mouse_x = x
         self.mouse_y = y
 
-        if self.on_mouse_release:
-            self.on_mouse_release(x, y)
+        for callback in list(self.on_mouse_release):
+            if callback(x, y):
+                break
 
     def handle_mouse_drag(self, x: float, y: float):
         """Called when mouse is dragged"""
@@ -71,29 +73,39 @@ class InputEvents:
         self.mouse_x = x
         self.mouse_y = y
 
-        if self.on_mouse_drag:
-            self.on_mouse_drag(dx, dy)
+        for callback in list(self.on_mouse_drag):
+            if callback(dx, dy):
+                break
 
-    def register_mouse_drag_callback(self, callback: Callable[[float, float], None]):
+    def register_mouse_drag_callback(
+        self, callback: Callable[[float, float], bool | None]
+    ):
         """Register a callback for mouse drag events"""
-        self.on_mouse_drag = callback
+        self.on_mouse_drag.append(callback)
 
-    def register_mouse_press_callback(self, callback: Callable[[float, float], None]):
+    def register_mouse_press_callback(
+        self, callback: Callable[[float, float], bool | None]
+    ):
         """Register a callback for mouse press events"""
-        self.on_mouse_press = callback
+        self.on_mouse_press.append(callback)
 
-    def register_mouse_release_callback(self, callback: Callable[[float, float], None]):
+    def register_mouse_release_callback(
+        self, callback: Callable[[float, float], bool | None]
+    ):
         """Register a callback for mouse release events"""
-        self.on_mouse_release = callback
+        self.on_mouse_release.append(callback)
 
     def handle_mouse_scroll(self, scroll_x: float, scroll_y: float):
         """Called when mouse wheel is scrolled"""
-        if self.on_mouse_scroll:
-            self.on_mouse_scroll(scroll_x, scroll_y)
+        for callback in list(self.on_mouse_scroll):
+            if callback(scroll_x, scroll_y):
+                break
 
-    def register_mouse_scroll_callback(self, callback: Callable[[float, float], None]):
+    def register_mouse_scroll_callback(
+        self, callback: Callable[[float, float], bool | None]
+    ):
         """Register a callback for mouse scroll events"""
-        self.on_mouse_scroll = callback
+        self.on_mouse_scroll.append(callback)
 
     @classmethod
     def get_instance(cls) -> "InputEvents":

--- a/parrot/utils/overlay_ui.py
+++ b/parrot/utils/overlay_ui.py
@@ -6,7 +6,12 @@ from beartype import beartype
 from parrot.director.mode import Mode
 from parrot.vj.vj_mode import VJMode
 from parrot.state import State
-from parrot.patch_bay import venues
+from parrot.patch_bay import (
+    get_all_venues,
+    get_supported_fixture_types,
+    get_venue_display_name,
+)
+from parrot.venue_editor import VenueEditorController
 from parrot.director.themes import themes
 
 
@@ -14,11 +19,21 @@ from parrot.director.themes import themes
 class OverlayUI:
     """ImGui overlay UI for mode selection and control"""
 
-    def __init__(self, pyglet_window, state: State):
+    def __init__(
+        self, pyglet_window, state: State, editor: VenueEditorController
+    ):
         self.state = state
+        self.editor = editor
         self.visible = False
         self.pyglet_window = pyglet_window
         self._first_render = True
+        self.editor_status = ""
+        self.new_venue_name = ""
+        self.new_light_address = 1
+        self.fixture_type_options = get_supported_fixture_types()
+        self.selected_fixture_type_idx = 0
+        self.floor_size_input = self.editor.get_floor_size_feet()
+        self._last_venue_name = self.state.venue.name
 
         # Initialize ImGui context
         imgui.create_context()
@@ -29,7 +44,7 @@ class OverlayUI:
 
         # UI dimensions (doubled from original 250x200, increased for venue/theme/vj_mode)
         self.window_width = 500
-        self.window_height = 630
+        self.window_height = 920
         self.button_width = 440
         self.button_height = 60
 
@@ -56,6 +71,10 @@ class OverlayUI:
         """Render the overlay UI if visible"""
         if not self.visible:
             return
+
+        if self._last_venue_name != self.state.venue.name:
+            self.floor_size_input = self.editor.get_floor_size_feet()
+            self._last_venue_name = self.state.venue.name
 
         # Fix for first-render mouse input issue:
         # Event callbacks only fire when events happen. If the mouse hasn't moved
@@ -143,14 +162,15 @@ class OverlayUI:
 
             # Venue selection
             imgui.text("Venue")
-            venue_names = [v.name for v in venues]
-            current_venue_idx = list(venues).index(self.state.venue)
+            venue_options = get_all_venues()
+            venue_names = [get_venue_display_name(venue) for venue in venue_options]
+            current_venue_idx = venue_options.index(self.state.venue)
             clicked, new_venue_idx = imgui.combo(
                 "##venue", current_venue_idx, venue_names
             )
             if clicked and new_venue_idx != current_venue_idx:
-                self.state.set_venue(list(venues)[new_venue_idx])
-                print(f"🏛️  Venue changed to: {venue_names[new_venue_idx]}")
+                self.state.set_venue(venue_options[new_venue_idx])
+                self.floor_size_input = self.editor.get_floor_size_feet()
 
             imgui.spacing()
 
@@ -164,6 +184,120 @@ class OverlayUI:
             if clicked and new_theme_idx != current_theme_idx:
                 self.state.set_theme(themes[new_theme_idx])
                 print(f"🎨 Color scheme changed to: {theme_names[new_theme_idx]}")
+
+            if self.state.show_fixture_mode:
+                imgui.spacing()
+                imgui.separator()
+                imgui.spacing()
+                imgui.text("3D Venue Editor")
+
+                selected_label = self.editor.get_selected_label()
+                imgui.text(f"Selected: {selected_label}")
+                selection_options = self.editor.get_selection_options()
+                selection_labels = [label for _, label in selection_options]
+                current_selection_key = self.editor.get_selected_key()
+                current_selection_idx = 0
+                for idx, (key, _) in enumerate(selection_options):
+                    if key == current_selection_key:
+                        current_selection_idx = idx
+                        break
+                clicked, new_selection_idx = imgui.combo(
+                    "Target", current_selection_idx, selection_labels
+                )
+                if clicked and new_selection_idx != current_selection_idx:
+                    self.editor.select_target_by_key(
+                        selection_options[new_selection_idx][0]
+                    )
+                if imgui.button("Prev Target", 138, 36):
+                    prev_index = (current_selection_idx - 1) % len(selection_options)
+                    self.editor.select_target_by_key(selection_options[prev_index][0])
+                imgui.same_line()
+                if imgui.button("Next Target", 138, 36):
+                    next_index = (current_selection_idx + 1) % len(selection_options)
+                    self.editor.select_target_by_key(selection_options[next_index][0])
+                imgui.same_line()
+                if imgui.button("Video Wall", 138, 36):
+                    self.editor.select_target_by_key("__video_wall__")
+
+                for mode_name, label in (
+                    ("select", "Select"),
+                    ("move", "Move"),
+                    ("rotate", "Rotate"),
+                ):
+                    if self.editor.get_mode() == mode_name:
+                        imgui.push_style_color(imgui.COLOR_BUTTON, 0.2, 0.45, 0.8, 1.0)
+                        imgui.push_style_color(
+                            imgui.COLOR_BUTTON_HOVERED, 0.25, 0.55, 0.9, 1.0
+                        )
+                        imgui.push_style_color(
+                            imgui.COLOR_BUTTON_ACTIVE, 0.25, 0.65, 1.0, 1.0
+                        )
+                    if imgui.button(label, 138, 44):
+                        self.editor.set_mode(mode_name)
+                    if self.editor.get_mode() == mode_name:
+                        imgui.pop_style_color(3)
+                    if mode_name != "rotate":
+                        imgui.same_line()
+
+                imgui.spacing()
+                imgui.text_wrapped(
+                    "Select a light or the video wall in the 3D view, then use move or rotate mode to drag the axis gizmo handles."
+                )
+                if imgui.button("-1 ft", 100, 36):
+                    self.floor_size_input = max(1.0, self.floor_size_input - 1.0)
+                imgui.same_line()
+                if imgui.button("+1 ft", 100, 36):
+                    self.floor_size_input += 1.0
+                imgui.same_line()
+                if imgui.button("+5 ft", 100, 36):
+                    self.floor_size_input += 5.0
+
+                changed, self.floor_size_input = imgui.input_float(
+                    "Floor size (ft)", self.floor_size_input, 1.0, 5.0, "%.1f"
+                )
+                if imgui.button("Apply Floor Size", 220, 40):
+                    self.editor.set_floor_size_feet(max(1.0, self.floor_size_input))
+                    self.floor_size_input = self.editor.get_floor_size_feet()
+                    self.editor_status = "Floor size updated."
+
+                imgui.spacing()
+                imgui.text("Add Light")
+                fixture_type_names = [label for _, label in self.fixture_type_options]
+                clicked, self.selected_fixture_type_idx = imgui.combo(
+                    "Fixture type",
+                    self.selected_fixture_type_idx,
+                    fixture_type_names,
+                )
+                changed, self.new_light_address = imgui.input_int(
+                    "DMX address", self.new_light_address
+                )
+                if imgui.button("Add Light", 220, 44):
+                    fixture_type = self.fixture_type_options[
+                        self.selected_fixture_type_idx
+                    ][0]
+                    try:
+                        self.editor.add_light(fixture_type, int(self.new_light_address))
+                        self.editor_status = "Light added."
+                    except ValueError as exc:
+                        self.editor_status = str(exc)
+
+                imgui.spacing()
+                imgui.text("Add Venue")
+                changed, self.new_venue_name = imgui.input_text(
+                    "Venue name", self.new_venue_name, 128
+                )
+                if imgui.button("Create Venue", 220, 44):
+                    try:
+                        self.editor.add_venue(self.new_venue_name)
+                        self.new_venue_name = ""
+                        self.floor_size_input = self.editor.get_floor_size_feet()
+                        self.editor_status = "Venue created."
+                    except ValueError as exc:
+                        self.editor_status = str(exc)
+
+                if self.editor_status:
+                    imgui.spacing()
+                    imgui.text_wrapped(self.editor_status)
 
         imgui.end()
 

--- a/parrot/venue_editor.py
+++ b/parrot/venue_editor.py
@@ -1,0 +1,408 @@
+from dataclasses import dataclass
+
+import numpy as np
+from beartype import beartype
+from beartype.typing import Any, Callable, Literal, Optional
+
+from parrot.fixtures.position_manager import FixturePositionManager
+from parrot.patch_bay import (
+    add_custom_venue,
+    add_fixture_to_venue,
+    get_venue_display_name,
+)
+from parrot.state import State
+from parrot.utils.input_events import InputEvents
+from parrot.vj.renderers.base import quaternion_from_axis_angle, quaternion_multiply
+
+EditorMode = Literal["select", "move", "rotate"]
+
+
+@beartype
+@dataclass
+class SelectionTarget:
+    kind: Literal["fixture", "video_wall"]
+    fixture_id: Optional[str] = None
+
+
+@beartype
+class VenueEditorController:
+    def __init__(self, state: State, position_manager: FixturePositionManager):
+        self.state = state
+        self.position_manager = position_manager
+        self.mode: EditorMode = "select"
+        self.selected_target: Optional[SelectionTarget] = None
+        self.room_renderer: Any | None = None
+        self.renderers: list[Any] = []
+        self.canvas_size = (1200.0, 1200.0)
+        self.video_wall_config: dict[str, float] = (
+            self.position_manager.get_video_wall_config()
+        )
+        self.patch_change_callback: Optional[Callable[[], None]] = None
+        self.active_drag_axis: Optional[str] = None
+        self.layout_dirty = False
+        self.gizmo_axis_length = 1.0
+        self.selection_threshold_px = 28.0
+
+        input_events = InputEvents.get_instance()
+        input_events.register_mouse_press_callback(self._on_mouse_press)
+        input_events.register_mouse_drag_callback(self._on_mouse_drag)
+        input_events.register_mouse_release_callback(self._on_mouse_release)
+
+    def set_patch_change_callback(self, callback: Callable[[], None]) -> None:
+        self.patch_change_callback = callback
+
+    def set_mode(self, mode: EditorMode) -> None:
+        self.mode = mode
+        self.active_drag_axis = None
+
+    def update_scene(
+        self,
+        room_renderer: Any,
+        renderers: list[Any],
+        canvas_size: tuple[float, float],
+        video_wall_config: dict[str, float],
+    ) -> None:
+        self.room_renderer = room_renderer
+        self.renderers = renderers
+        self.canvas_size = canvas_size
+        self.video_wall_config = dict(video_wall_config)
+
+    def get_mode(self) -> EditorMode:
+        return self.mode
+
+    def get_selected_label(self) -> str:
+        if self.selected_target is None:
+            return "None"
+        if self.selected_target.kind == "video_wall":
+            return "Video Wall"
+        renderer = self._get_selected_renderer()
+        if renderer is None:
+            return "None"
+        return f"{renderer.fixture.name} @ {renderer.fixture.address}"
+
+    def get_selection_options(self) -> list[tuple[str, str]]:
+        options: list[tuple[str, str]] = [("__none__", "None"), ("__video_wall__", "Video Wall")]
+        for renderer in self.renderers:
+            options.append(
+                (
+                    renderer.fixture.id,
+                    f"{renderer.fixture.name} @ {renderer.fixture.address}",
+                )
+            )
+        return options
+
+    def get_selected_key(self) -> str:
+        if self.selected_target is None:
+            return "__none__"
+        if self.selected_target.kind == "video_wall":
+            return "__video_wall__"
+        return self.selected_target.fixture_id or "__none__"
+
+    def select_target_by_key(self, key: str) -> None:
+        if key == "__none__":
+            self.selected_target = None
+            self.active_drag_axis = None
+            return
+        if key == "__video_wall__":
+            self.selected_target = SelectionTarget(kind="video_wall")
+            self.active_drag_axis = None
+            return
+        self.selected_target = SelectionTarget(kind="fixture", fixture_id=key)
+        self.active_drag_axis = None
+
+    def get_floor_size_feet(self) -> float:
+        return self.position_manager.get_floor_size_feet()
+
+    def set_floor_size_feet(self, floor_size_feet: float) -> None:
+        self.position_manager.venue_metadata["floor_size_feet"] = float(floor_size_feet)
+        if self.room_renderer is not None:
+            self.room_renderer.set_floor_size_feet(float(floor_size_feet))
+        self.position_manager.save_current_venue_layout()
+
+    def add_venue(self, display_name: str) -> None:
+        venue = add_custom_venue(display_name)
+        self.state.set_venue(venue)
+        self.selected_target = None
+        self.mode = "select"
+
+    def add_light(self, fixture_type: str, address: int) -> None:
+        fixture = add_fixture_to_venue(self.state.venue, fixture_type, address)
+        self.position_manager.reload_current_venue_layout()
+
+        occupied_positions = [
+            renderer.position for renderer in self.renderers if renderer is not None
+        ]
+        new_x, new_y, new_z = self._next_default_fixture_position(occupied_positions)
+        self.position_manager.set_fixture_position(fixture, new_x, new_y, new_z)
+        self.position_manager.set_fixture_orientation(
+            fixture, np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+        )
+        self.position_manager.save_current_venue_layout()
+
+        if self.patch_change_callback is not None:
+            self.patch_change_callback()
+        self.selected_target = SelectionTarget(kind="fixture", fixture_id=fixture.id)
+        self.mode = "move"
+
+    def render_gizmo(self) -> None:
+        if (
+            self.room_renderer is None
+            or self.selected_target is None
+            or self.mode not in ("move", "rotate")
+        ):
+            return
+
+        origin = self._get_selected_origin()
+        if origin is None:
+            return
+
+        active_axis = self.active_drag_axis if self.mode == "move" else None
+        self.room_renderer.render_axis_gizmo(
+            origin,
+            active_axis=active_axis,
+            axis_length=self.gizmo_axis_length,
+        )
+
+    def _on_mouse_press(self, x: float, y: float) -> bool:
+        if not self._editor_enabled():
+            return False
+
+        if self.selected_target is not None and self.mode in ("move", "rotate"):
+            handle = self._pick_axis_handle(x, y)
+            if handle is not None:
+                axis_name, direction = handle
+                if self.mode == "move":
+                    self.active_drag_axis = axis_name
+                else:
+                    self._rotate_selected(axis_name, direction)
+                return True
+
+        picked_target = self._pick_target(x, y)
+        if picked_target is not None:
+            self.selected_target = picked_target
+            self.active_drag_axis = None
+            return True
+
+        return False
+
+    def _on_mouse_drag(self, dx: float, dy: float) -> bool:
+        if (
+            not self._editor_enabled()
+            or self.mode != "move"
+            or self.active_drag_axis is None
+        ):
+            return False
+
+        origin = self._get_selected_origin()
+        if origin is None or self.room_renderer is None:
+            return False
+
+        axis_vector = self._axis_unit_vectors()[self.active_drag_axis]
+        axis_end = (
+            origin[0] + axis_vector[0],
+            origin[1] + axis_vector[1],
+            origin[2] + axis_vector[2],
+        )
+        screen_origin = self.room_renderer.project_world_to_screen(origin)
+        screen_end = self.room_renderer.project_world_to_screen(axis_end)
+        if screen_origin is None or screen_end is None:
+            return True
+
+        axis_screen = np.array(
+            [screen_end[0] - screen_origin[0], screen_end[1] - screen_origin[1]],
+            dtype=np.float32,
+        )
+        axis_length = float(np.linalg.norm(axis_screen))
+        if axis_length < 1e-5:
+            return True
+
+        axis_unit = axis_screen / axis_length
+        projected_pixels = float(dx * axis_unit[0] + dy * axis_unit[1])
+        world_delta = projected_pixels / axis_length
+        self._move_selected(self.active_drag_axis, world_delta)
+        return True
+
+    def _on_mouse_release(self, x: float, y: float) -> bool:
+        if self.active_drag_axis is not None:
+            self.active_drag_axis = None
+            if self.layout_dirty:
+                self.position_manager.save_current_venue_layout()
+                self.layout_dirty = False
+            return True
+        if self.layout_dirty:
+            self.position_manager.save_current_venue_layout()
+            self.layout_dirty = False
+        return False
+
+    def _editor_enabled(self) -> bool:
+        return self.state.show_fixture_mode and self.room_renderer is not None
+
+    def _axis_unit_vectors(self) -> dict[str, tuple[float, float, float]]:
+        return {
+            "x": (1.0, 0.0, 0.0),
+            "y": (0.0, 1.0, 0.0),
+            "z": (0.0, 0.0, 1.0),
+        }
+
+    def _get_selected_renderer(self) -> Any | None:
+        if self.selected_target is None or self.selected_target.kind != "fixture":
+            return None
+        for renderer in self.renderers:
+            if renderer.fixture.id == self.selected_target.fixture_id:
+                return renderer
+        return None
+
+    def _get_selected_origin(self) -> Optional[tuple[float, float, float]]:
+        if self.selected_target is None:
+            return None
+        if self.selected_target.kind == "video_wall":
+            return (
+                float(self.video_wall_config["x"]),
+                float(self.video_wall_config["y"]),
+                float(self.video_wall_config["z"]),
+            )
+
+        renderer = self._get_selected_renderer()
+        if renderer is None:
+            return None
+        return renderer.get_3d_position(self.canvas_size)
+
+    def _pick_target(self, mouse_x: float, mouse_y: float) -> Optional[SelectionTarget]:
+        if self.room_renderer is None:
+            return None
+
+        closest_target: Optional[SelectionTarget] = None
+        closest_distance = self.selection_threshold_px
+
+        for renderer in self.renderers:
+            screen_pos = self.room_renderer.project_world_to_screen(
+                renderer.get_3d_position(self.canvas_size)
+            )
+            if screen_pos is None:
+                continue
+            distance = self._screen_distance(screen_pos, (mouse_x, mouse_y))
+            if distance < closest_distance:
+                closest_distance = distance
+                closest_target = SelectionTarget(
+                    kind="fixture", fixture_id=renderer.fixture.id
+                )
+
+        video_wall_screen = self.room_renderer.project_world_to_screen(
+            (
+                float(self.video_wall_config["x"]),
+                float(self.video_wall_config["y"]),
+                float(self.video_wall_config["z"]),
+            )
+        )
+        if video_wall_screen is not None:
+            distance = self._screen_distance(video_wall_screen, (mouse_x, mouse_y))
+            if distance < closest_distance + 18.0:
+                closest_target = SelectionTarget(kind="video_wall")
+
+        return closest_target
+
+    def _pick_axis_handle(
+        self, mouse_x: float, mouse_y: float
+    ) -> Optional[tuple[str, int]]:
+        origin = self._get_selected_origin()
+        if origin is None or self.room_renderer is None:
+            return None
+
+        closest_handle: Optional[tuple[str, int]] = None
+        closest_distance = self.selection_threshold_px
+
+        for axis_name, axis_vector in self._axis_unit_vectors().items():
+            for direction in (-1, 1):
+                handle_world = (
+                    origin[0] + axis_vector[0] * self.gizmo_axis_length * direction,
+                    origin[1] + axis_vector[1] * self.gizmo_axis_length * direction,
+                    origin[2] + axis_vector[2] * self.gizmo_axis_length * direction,
+                )
+                screen_pos = self.room_renderer.project_world_to_screen(handle_world)
+                if screen_pos is None:
+                    continue
+                distance = self._screen_distance(screen_pos, (mouse_x, mouse_y))
+                if distance < closest_distance:
+                    closest_distance = distance
+                    closest_handle = (axis_name, direction)
+
+        return closest_handle
+
+    def _move_selected(self, axis_name: str, world_delta: float) -> None:
+        origin = self._get_selected_origin()
+        if origin is None or self.room_renderer is None:
+            return
+
+        axis_index = {"x": 0, "y": 1, "z": 2}[axis_name]
+        next_origin = [origin[0], origin[1], origin[2]]
+        next_origin[axis_index] += world_delta
+
+        if self.selected_target is None:
+            return
+
+        if self.selected_target.kind == "video_wall":
+            self.position_manager.venue_metadata["video_wall"][axis_name] = float(
+                next_origin[axis_index]
+            )
+            self.video_wall_config = self.position_manager.get_video_wall_config()
+        else:
+            renderer = self._get_selected_renderer()
+            if renderer is None:
+                return
+            canvas_x, canvas_y, height = self.room_renderer.convert_3d_to_2d(
+                float(next_origin[0]), float(next_origin[1]), float(next_origin[2])
+            )
+            self.position_manager.set_fixture_position(
+                renderer.fixture, canvas_x, canvas_y, height
+            )
+            renderer.set_position(canvas_x, canvas_y, height)
+
+        self.layout_dirty = True
+
+    def _rotate_selected(self, axis_name: str, direction: int) -> None:
+        if self.selected_target is None or self.selected_target.kind != "fixture":
+            return
+
+        renderer = self._get_selected_renderer()
+        if renderer is None:
+            return
+
+        axis_vector = np.array(self._axis_unit_vectors()[axis_name], dtype=np.float32)
+        delta_quaternion = quaternion_from_axis_angle(
+            axis_vector, direction * (np.pi / 4.0)
+        )
+        updated_orientation = quaternion_multiply(
+            delta_quaternion, renderer.orientation
+        )
+        renderer.orientation = updated_orientation
+        self.position_manager.set_fixture_orientation(
+            renderer.fixture, updated_orientation
+        )
+        self.position_manager.save_current_venue_layout()
+
+    def _screen_distance(
+        self, point_a: tuple[float, float], point_b: tuple[float, float]
+    ) -> float:
+        return float(
+            np.linalg.norm(
+                np.array([point_a[0] - point_b[0], point_a[1] - point_b[1]])
+            )
+        )
+
+    def _next_default_fixture_position(
+        self, occupied_positions: list[tuple[float, float, float]]
+    ) -> tuple[float, float, float]:
+        if not occupied_positions:
+            return (250.0, 250.0, 3.0)
+
+        max_x = max(position[0] for position in occupied_positions)
+        max_y = max(position[1] for position in occupied_positions)
+        next_x = max_x + 60.0
+        next_y = max_y
+        if next_x > 460.0:
+            next_x = 40.0
+            next_y = max_y + 60.0
+        return (next_x, next_y, 3.0)
+
+    def get_current_venue_label(self) -> str:
+        return get_venue_display_name(self.state.venue)

--- a/parrot/vj/nodes/fixture_visualization.py
+++ b/parrot/vj/nodes/fixture_visualization.py
@@ -21,6 +21,7 @@ from parrot.vj.renderers.motionstrip import MotionstripRenderer
 from parrot.vj.renderers.laser import LaserRenderer
 from parrot.state import State
 from parrot.fixtures.position_manager import FixturePositionManager
+from parrot.venue_editor import VenueEditorController
 from parrot.vj.shaders import kawase_blur, composite
 from parrot.vj.vj_director import VJDirector
 from typing import Optional
@@ -63,6 +64,7 @@ class FixtureVisualization(GenerativeEffectBase):
         self.vj_director = vj_director
         self.canvas_width = canvas_width
         self.canvas_height = canvas_height
+        self.editor = VenueEditorController(state, position_manager)
 
         # Subscribe to venue changes to reload fixtures
         self.state.events.on_venue_change += self._on_venue_change
@@ -164,6 +166,10 @@ class FixtureVisualization(GenerativeEffectBase):
 
     def _on_venue_change(self, venue):
         """Reload fixtures when venue changes (position manager handles positions)"""
+        self._load_fixtures()
+
+    def reload_fixtures(self) -> None:
+        self.position_manager.reload_current_venue_layout()
         self._load_fixtures()
 
     def _load_fixtures(self):
@@ -331,13 +337,13 @@ class FixtureVisualization(GenerativeEffectBase):
 
                 # Add fixture world position
                 bulb_world_pos = (
-                    fixture_world_pos[0] + bulb_pos_oriented[0],
-                    fixture_world_pos[1] + bulb_pos_oriented[1],
-                    fixture_world_pos[2] + bulb_pos_oriented[2],
+                    float(fixture_world_pos[0] + bulb_pos_oriented[0]),
+                    float(fixture_world_pos[1] + bulb_pos_oriented[1]),
+                    float(fixture_world_pos[2] + bulb_pos_oriented[2]),
                 )
 
                 # Create light entry: position, (r, g, b, intensity)
-                lights.append((bulb_world_pos, (r, g, b, effective_intensity)))
+                lights.append((bulb_world_pos, (float(r), float(g), float(b), float(effective_intensity))))
             except Exception:
                 pass  # Skip bulbs that can't be processed
 
@@ -431,7 +437,15 @@ class FixtureVisualization(GenerativeEffectBase):
         # Initialize room renderer if needed
         if self.room_renderer is None:
             self.room_renderer = Room3DRenderer(
-                context, self.width, self.height, show_floor=True
+                context,
+                self.width,
+                self.height,
+                show_floor=True,
+                floor_size_feet=self.position_manager.get_floor_size_feet(),
+            )
+        else:
+            self.room_renderer.set_floor_size_feet(
+                self.position_manager.get_floor_size_feet()
             )
 
         # Create or recreate renderers if fixtures changed (venue change)
@@ -448,20 +462,26 @@ class FixtureVisualization(GenerativeEffectBase):
 
         # Set global lighting based on VJ content
         self.room_renderer.set_global_light_color(global_light_color)
+        video_wall = self.position_manager.get_video_wall_config()
 
         # Collect and set dynamic lights from fixtures
         fixture_lights = self._collect_fixture_lights(frame)
 
         # Add video wall as a light source if it's active
         if video_wall_color is not None:
-            # Video wall position (center of billboard at back of room)
-            billboard_height = 6.0
-            video_wall_pos = (0.0, billboard_height / 2.0, -4.5)
+            video_wall_pos = (
+                float(video_wall["x"]),
+                float(video_wall["y"]),
+                float(video_wall["z"]),
+            )
             fixture_lights.append((video_wall_pos, video_wall_color))
 
         self.room_renderer.set_dynamic_lights(fixture_lights)
 
         canvas_size = (float(self.canvas_width), float(self.canvas_height))
+        self.editor.update_scene(
+            self.room_renderer, self.renderers, canvas_size, video_wall
+        )
 
         # === PASS 1: Render opaque Blinn-Phong geometry ===
         self.opaque_framebuffer.use()
@@ -480,23 +500,23 @@ class FixtureVisualization(GenerativeEffectBase):
 
         # Render VJ output on billboard at back of room (upstage behind DJ)
         if vj_texture:
-            # Large billboard at back of room, floor to ceiling
-            billboard_width = 10.0  # Wide screen
-            billboard_height = 6.0  # Floor to near-ceiling
-            # Position: centered horizontally (x=0), bottom at floor + half height
-            y_pos = billboard_height / 2.0
-
             self.room_renderer.render_billboard(
                 texture=vj_texture,
-                position=(0.0, y_pos, -4.5),  # Back of room, centered, floor to ceiling
-                width=billboard_width,
-                height=billboard_height,
+                position=(
+                    float(video_wall["x"]),
+                    float(video_wall["y"]),
+                    float(video_wall["z"]),
+                ),
+                width=float(video_wall["width"]),
+                height=float(video_wall["height"]),
                 normal=(0.0, 0.0, 1.0),  # Face forward toward audience
             )
 
         # Render fixture bodies (Blinn-Phong materials)
         for renderer in self.renderers:
             renderer.render_opaque(context, canvas_size, frame)
+
+        self.editor.render_gizmo()
 
         # === PASS 2: Render emissive materials (bulbs and beams, excluding lasers) ===
         self.emissive_framebuffer.use()

--- a/parrot/vj/renderers/room_3d.py
+++ b/parrot/vj/renderers/room_3d.py
@@ -23,7 +23,12 @@ class Room3DRenderer:
     """3D room renderer with floor grid and 3D fixture cubes"""
 
     def __init__(
-        self, context: mgl.Context, width: int, height: int, show_floor: bool = False
+        self,
+        context: mgl.Context,
+        width: int,
+        height: int,
+        show_floor: bool = False,
+        floor_size_feet: float = 10.0,
     ):
         self.ctx = context
         self.width = width
@@ -59,6 +64,7 @@ class Room3DRenderer:
 
         # Floor grid parameters
         self.grid_size = 1.0  # Size of each grid square
+        self.floor_size_feet = float(floor_size_feet)
         self.floor_color = (0.1, 0.1, 0.1)  # Dark floor
         self.grid_color = (0.25, 0.25, 0.25)  # Darker grey gridlines
 
@@ -400,11 +406,13 @@ class Room3DRenderer:
 
     def _setup_floor_geometry(self):
         """Create floor grid geometry with normals"""
+        half_floor = self.floor_size_feet / 2.0
+
         # Floor quad vertices (dark)
-        back_left = (-5.0, 0.0, -5.0)
-        back_right = (5.0, 0.0, -5.0)
-        front_left = (-5.0, 0.0, 5.0)
-        front_right = (5.0, 0.0, 5.0)
+        back_left = (-half_floor, 0.0, -half_floor)
+        back_right = (half_floor, 0.0, -half_floor)
+        front_left = (-half_floor, 0.0, half_floor)
+        front_right = (half_floor, 0.0, half_floor)
 
         # Floor normal (pointing up)
         floor_normal = (0.0, 1.0, 0.0)
@@ -490,15 +498,17 @@ class Room3DRenderer:
     def _create_grid_lines(self):
         """Create grid lines for the floor"""
         lines = []
+        half_floor = self.floor_size_feet / 2.0
+        line_count = int(math.floor(half_floor))
 
         # Simple grid lines in visible range
         # Horizontal lines (across the floor)
-        for i in range(-5, 6):
-            lines.append([-5.0, 0.001, i, 5.0, 0.001, i])
+        for i in range(-line_count, line_count + 1):
+            lines.append([-half_floor, 0.001, float(i), half_floor, 0.001, float(i)])
 
         # Vertical lines (along the floor)
-        for i in range(-5, 6):
-            lines.append([i, 0.001, -5.0, i, 0.001, 5.0])
+        for i in range(-line_count, line_count + 1):
+            lines.append([float(i), 0.001, -half_floor, float(i), 0.001, half_floor])
 
         return lines
 
@@ -588,6 +598,7 @@ class Room3DRenderer:
         self.camera_tilt = max(
             self.min_camera_tilt, min(self.max_camera_tilt, self.camera_tilt)
         )
+        return False
 
     def _on_mouse_scroll(self, scroll_x: float, scroll_y: float):
         """Handle mouse scroll to zoom camera in/out"""
@@ -599,6 +610,126 @@ class Room3DRenderer:
             self.min_camera_distance,
             min(self.max_camera_distance, self.camera_distance),
         )
+        return False
+
+    def set_floor_size_feet(self, floor_size_feet: float):
+        next_floor_size = float(floor_size_feet)
+        if abs(self.floor_size_feet - next_floor_size) < 1e-5:
+            return
+        self.floor_size_feet = next_floor_size
+        if not self.show_floor:
+            return
+
+        for attribute_name in (
+            "floor_vbo",
+            "floor_normal_vbo",
+            "floor_color_vbo",
+            "floor_vao",
+            "grid_vbo",
+            "grid_normal_vbo",
+            "grid_color_vbo",
+            "grid_vao",
+        ):
+            resource = getattr(self, attribute_name, None)
+            if resource is not None:
+                resource.release()
+                delattr(self, attribute_name)
+        self._setup_floor_geometry()
+
+    def project_world_to_screen(
+        self, position: tuple[float, float, float]
+    ) -> Optional[tuple[float, float]]:
+        x, y, z = position
+        world = np.array([x, y, z, 1.0], dtype=np.float32)
+        clip = self._get_mvp_matrix() @ world
+        w = float(clip[3])
+        if abs(w) < 1e-5:
+            return None
+        ndc = clip[:3] / w
+        screen_x = float((ndc[0] * 0.5 + 0.5) * self.width)
+        screen_y = float(((-ndc[1]) * 0.5 + 0.5) * self.height)
+        return (screen_x, screen_y)
+
+    def render_axis_gizmo(
+        self,
+        origin: tuple[float, float, float],
+        active_axis: Optional[str] = None,
+        axis_length: float = 1.0,
+        line_thickness: float = 0.05,
+        handle_size: float = 0.16,
+    ):
+        x, y, z = origin
+        axis_colors = {
+            "x": (1.0, 0.2, 0.2),
+            "y": (0.2, 1.0, 0.2),
+            "z": (0.2, 0.5, 1.0),
+        }
+
+        for axis_name, color in axis_colors.items():
+            axis_color = color if active_axis != axis_name else (1.0, 1.0, 0.2)
+            if axis_name == "x":
+                self.render_rectangular_box(
+                    x + axis_length / 2.0,
+                    y - line_thickness / 2.0,
+                    z,
+                    axis_color,
+                    axis_length,
+                    line_thickness,
+                    line_thickness,
+                )
+                self.render_rectangular_box(
+                    x - axis_length / 2.0,
+                    y - line_thickness / 2.0,
+                    z,
+                    axis_color,
+                    axis_length,
+                    line_thickness,
+                    line_thickness,
+                )
+                self.render_cube((x + axis_length, y, z), axis_color, handle_size)
+                self.render_cube((x - axis_length, y, z), axis_color, handle_size)
+            elif axis_name == "y":
+                self.render_rectangular_box(
+                    x,
+                    y,
+                    z,
+                    axis_color,
+                    line_thickness,
+                    axis_length,
+                    line_thickness,
+                )
+                self.render_rectangular_box(
+                    x,
+                    y - axis_length,
+                    z,
+                    axis_color,
+                    line_thickness,
+                    axis_length,
+                    line_thickness,
+                )
+                self.render_cube((x, y + axis_length, z), axis_color, handle_size)
+                self.render_cube((x, y - axis_length, z), axis_color, handle_size)
+            else:
+                self.render_rectangular_box(
+                    x,
+                    y - line_thickness / 2.0,
+                    z + axis_length / 2.0,
+                    axis_color,
+                    line_thickness,
+                    line_thickness,
+                    axis_length,
+                )
+                self.render_rectangular_box(
+                    x,
+                    y - line_thickness / 2.0,
+                    z - axis_length / 2.0,
+                    axis_color,
+                    line_thickness,
+                    line_thickness,
+                    axis_length,
+                )
+                self.render_cube((x, y, z + axis_length), axis_color, handle_size)
+                self.render_cube((x, y, z - axis_length), axis_color, handle_size)
 
     def set_global_light_color(self, color: tuple[float, float, float]):
         """Set the global lighting color (affects directional, point, and ambient lights)"""
@@ -2151,7 +2282,7 @@ class Room3DRenderer:
         # Assume fixtures are positioned in a [0-500] coordinate system
         # Map to floor space which is [-5 to 5] in both X and Z
         fixture_coord_range = 500.0
-        floor_size = 10.0  # Floor goes from -5 to 5
+        floor_size = self.floor_size_feet
 
         # Normalize to [0-1] range assuming [0-500] input
         norm_x = x / fixture_coord_range
@@ -2169,6 +2300,17 @@ class Room3DRenderer:
         room_y = z
 
         return room_x, room_y, room_z
+
+    def convert_3d_to_2d(
+        self, room_x: float, room_y: float, room_z: float
+    ) -> tuple[float, float, float]:
+        fixture_coord_range = 500.0
+        floor_size = self.floor_size_feet
+        norm_x = (room_x / floor_size) + 0.5
+        norm_y = (room_z / floor_size) + 0.5
+        x = norm_x * fixture_coord_range
+        y = norm_y * fixture_coord_range
+        return x, y, room_y
 
     def cleanup(self):
         """Clean up OpenGL resources"""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a config-backed venue editor model so built-in venues can gain new fixtures and custom venues can be created at runtime
- add 3D editor state, target selection, move/rotate modes, floor-size metadata, and video-wall transform persistence
- extend the fixture-mode overlay with venue editor controls for floor sizing, target selection, light creation, and venue creation
- add focused tests covering custom venue/light persistence, floor/video-wall metadata, and editor transform helpers

## Testing
- `PYTHONPATH="$HOME/.local/lib/python3.12/site-packages:$PYTHONPATH" python3 -m pytest parrot/test_venue_editor.py parrot/fixtures/test_position_manager.py parrot/test_state.py`
- `PYTHONPATH="$HOME/.local/lib/python3.12/site-packages:$PYTHONPATH" python3 -m parrot.main --fixture-mode --start-with-overlay --no-web --screenshot` (run with mocked audio in the VM because there is no default audio input device)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-850519be-9d42-4fb2-a4c9-8df08aee02ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-850519be-9d42-4fb2-a4c9-8df08aee02ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

